### PR TITLE
Implement simple FastAPI voting server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# votaciones
+# Sistema de votaciones
+
+Este proyecto implementa un ejemplo simple de sistema de votación en tiempo real utilizando **FastAPI**. Existen tres tipos de usuarios:
+
+- **admin**: administrador del sistema.
+- **manager**: gestor con permisos para registrar miembros y candidatos.
+- **user**: votantes comunes.
+
+## Requisitos
+
+- Python 3.10+
+- Las dependencias enumeradas en `requirements.txt`.
+
+Instalación de dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Ejecutar el servidor con **uvicorn**:
+
+```bash
+uvicorn main:app --reload
+```
+
+### Endpoints principales
+
+- `POST /members` - Agregar miembros (requiere `acting_user` con rol *admin* o *manager*).
+- `POST /candidates` - Registrar candidatos (requiere `acting_user` con rol *admin* o *manager*).
+- `POST /vote` - Emitir un voto (`acting_user` debe existir y no haber votado antes).
+- `GET /results` - Obtener el conteo actual de votos.
+- `WS /ws` - WebSocket para recibir actualizaciones en tiempo real.
+
+Todos los datos se mantienen en memoria y se pierden al reiniciar la aplicación.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,92 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+from pydantic import BaseModel
+from typing import Dict
+
+app = FastAPI()
+
+class Member(BaseModel):
+    username: str
+    rut: str
+    role: str  # 'admin', 'manager', 'user'
+
+class Candidate(BaseModel):
+    id: int
+    name: str
+    votes: int = 0
+
+members: Dict[str, Member] = {}
+candidates: Dict[int, Candidate] = {}
+votes: Dict[str, int] = {}
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: dict):
+        for connection in self.active_connections:
+            try:
+                await connection.send_json(message)
+            except WebSocketDisconnect:
+                self.disconnect(connection)
+
+manager = ConnectionManager()
+
+# Utility functions
+
+def require_role(username: str, roles: list[str]):
+    member = members.get(username)
+    if not member or member.role not in roles:
+        raise HTTPException(status_code=403, detail="Insufficient privileges")
+    return member
+
+# Routes
+
+@app.post("/members")
+async def add_member(acting_user: str, member: Member):
+    require_role(acting_user, ["admin", "manager"])
+    if member.username in members:
+        raise HTTPException(status_code=400, detail="Member already exists")
+    members[member.username] = member
+    return member
+
+@app.post("/candidates")
+async def add_candidate(acting_user: str, candidate: Candidate):
+    require_role(acting_user, ["admin", "manager"])
+    if candidate.id in candidates:
+        raise HTTPException(status_code=400, detail="Candidate id exists")
+    candidates[candidate.id] = candidate
+    await manager.broadcast({"event": "candidate_added", "candidate": candidate.dict()})
+
+@app.post("/vote")
+async def vote(acting_user: str, candidate_id: int):
+    voter = require_role(acting_user, ["admin", "manager", "user"])
+    if acting_user in votes:
+        raise HTTPException(status_code=400, detail="User already voted")
+    candidate = candidates.get(candidate_id)
+    if not candidate:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    candidate.votes += 1
+    votes[acting_user] = candidate_id
+    await manager.broadcast({"event": "vote", "candidate_id": candidate_id, "votes": candidate.votes})
+    return {"candidate": candidate.name, "votes": candidate.votes}
+
+@app.get("/results")
+async def results():
+    return {cid: c.votes for cid, c in candidates.items()}
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()  # Keep connection alive
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+


### PR DESCRIPTION
## Summary
- add a basic FastAPI app implementing a simple voting system
- describe usage in the README
- list dependencies in requirements.txt

## Testing
- `python3 -m compileall -q main.py`
- `python3 -m uvicorn main:app --port 8000 --reload --dry-run` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_68425e7ad0f08325bd67286adda5065b