### PR TITLE
Add SQLModel persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Instalación de dependencias:
 pip install -r requirements.txt
 ```
 
+La base de datos SQLite se crea automáticamente al iniciar la aplicación.
+
 ## Uso
 
 Ejecutar el servidor con **uvicorn**:
@@ -33,4 +35,4 @@ uvicorn main:app --reload
 - `GET /results` - Obtener el conteo actual de votos.
 - `WS /ws` - WebSocket para recibir actualizaciones en tiempo real.
 
-Todos los datos se mantienen en memoria y se pierden al reiniciar la aplicación.
+Los datos se almacenan de forma persistente en un archivo `database.db` mediante **SQLModel**.

--- a/main.py
+++ b/main.py
@@ -1,22 +1,34 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
-from pydantic import BaseModel
-from typing import Dict
+from sqlmodel import Field, Session, SQLModel, create_engine, select
+from typing import Optional
 
 app = FastAPI()
 
-class Member(BaseModel):
-    username: str
+DATABASE_URL = "sqlite:///database.db"
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+class Member(SQLModel, table=True):
+    username: str = Field(primary_key=True)
     rut: str
     role: str  # 'admin', 'manager', 'user'
 
-class Candidate(BaseModel):
-    id: int
+
+class Candidate(SQLModel, table=True):
+    id: int = Field(primary_key=True)
     name: str
     votes: int = 0
 
-members: Dict[str, Member] = {}
-candidates: Dict[int, Candidate] = {}
-votes: Dict[str, int] = {}
+
+class Vote(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    voter_username: str = Field(foreign_key="member.username")
+    candidate_id: int = Field(foreign_key="candidate.id")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    SQLModel.metadata.create_all(engine)
 
 class ConnectionManager:
     def __init__(self):
@@ -42,45 +54,60 @@ manager = ConnectionManager()
 # Utility functions
 
 def require_role(username: str, roles: list[str]):
-    member = members.get(username)
-    if not member or member.role not in roles:
-        raise HTTPException(status_code=403, detail="Insufficient privileges")
-    return member
+    with Session(engine) as session:
+        member = session.get(Member, username)
+        if not member or member.role not in roles:
+            raise HTTPException(status_code=403, detail="Insufficient privileges")
+        return member
 
 # Routes
 
 @app.post("/members")
 async def add_member(acting_user: str, member: Member):
     require_role(acting_user, ["admin", "manager"])
-    if member.username in members:
-        raise HTTPException(status_code=400, detail="Member already exists")
-    members[member.username] = member
-    return member
+    with Session(engine) as session:
+        if session.get(Member, member.username):
+            raise HTTPException(status_code=400, detail="Member already exists")
+        session.add(member)
+        session.commit()
+        session.refresh(member)
+        return member
 
 @app.post("/candidates")
 async def add_candidate(acting_user: str, candidate: Candidate):
     require_role(acting_user, ["admin", "manager"])
-    if candidate.id in candidates:
-        raise HTTPException(status_code=400, detail="Candidate id exists")
-    candidates[candidate.id] = candidate
-    await manager.broadcast({"event": "candidate_added", "candidate": candidate.dict()})
+    with Session(engine) as session:
+        if session.get(Candidate, candidate.id):
+            raise HTTPException(status_code=400, detail="Candidate id exists")
+        session.add(candidate)
+        session.commit()
+        session.refresh(candidate)
+        await manager.broadcast({"event": "candidate_added", "candidate": candidate.dict()})
 
 @app.post("/vote")
 async def vote(acting_user: str, candidate_id: int):
-    voter = require_role(acting_user, ["admin", "manager", "user"])
-    if acting_user in votes:
-        raise HTTPException(status_code=400, detail="User already voted")
-    candidate = candidates.get(candidate_id)
-    if not candidate:
-        raise HTTPException(status_code=404, detail="Candidate not found")
-    candidate.votes += 1
-    votes[acting_user] = candidate_id
-    await manager.broadcast({"event": "vote", "candidate_id": candidate_id, "votes": candidate.votes})
-    return {"candidate": candidate.name, "votes": candidate.votes}
+    require_role(acting_user, ["admin", "manager", "user"])
+    with Session(engine) as session:
+        existing_vote = session.exec(select(Vote).where(Vote.voter_username == acting_user)).first()
+        if existing_vote:
+            raise HTTPException(status_code=400, detail="User already voted")
+        candidate = session.get(Candidate, candidate_id)
+        if not candidate:
+            raise HTTPException(status_code=404, detail="Candidate not found")
+        candidate.votes += 1
+        vote_entry = Vote(voter_username=acting_user, candidate_id=candidate_id)
+        session.add(vote_entry)
+        session.add(candidate)
+        session.commit()
+        session.refresh(candidate)
+        await manager.broadcast({"event": "vote", "candidate_id": candidate_id, "votes": candidate.votes})
+        return {"candidate": candidate.name, "votes": candidate.votes}
 
 @app.get("/results")
 async def results():
-    return {cid: c.votes for cid, c in candidates.items()}
+    with Session(engine) as session:
+        cands = session.exec(select(Candidate)).all()
+        return {c.id: c.votes for c in cands}
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
+sqlmodel
 


### PR DESCRIPTION
## Summary
- integrate SQLModel with SQLite
- persist Members, Candidates and Votes
- update documentation for the new persistence layer
- add SQLModel to requirements

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68425fb82b10832596bc3d93c5ead42c